### PR TITLE
fixing bug related to struct allocation in cgo in go1.15.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module pault.ag/go/ykpiv
 
 go 1.13
 
-require golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
+require (
+	github.com/aead/ecdh v0.2.0
+	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/aead/ecdh v0.2.0 h1:pYop54xVaq/CEREFEcukHRZfTdjiWvYIsZDXXrBapQQ=
+github.com/aead/ecdh v0.2.0/go.mod h1:a9HHtXuSo8J1Js1MwLQx2mBhkXMT6YwUmVVEY4tTB8U=
+golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc h1:c0o/qxkaO2LF5t6fQrT4b5hzyggAkLLlCUjqfRxd8Q4=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/ykpiv.go
+++ b/ykpiv.go
@@ -537,8 +537,9 @@ func (y Yubikey) GetCertificate(slotId SlotId) (*x509.Certificate, error) {
 // find the correct Yubikey, initialize the underlying state, and ensure
 // the right bits are set.
 func New(opts Options) (*Yubikey, error) {
+	var state *C.ykpiv_state
 	yubikey := Yubikey{
-		state:   &C.ykpiv_state{},
+		state:   state,
 		options: opts,
 	}
 
@@ -566,7 +567,7 @@ func New(opts Options) (*Yubikey, error) {
 // "Reader" argument in ykpiv.Options, and may include things ykpiv can't talk
 // to.
 func Readers() ([]string, error) {
-	state := &C.ykpiv_state{}
+	var state *C.ykpiv_state
 
 	if err := getError(C.ykpiv_init(&state, C.int(0)), "init"); err != nil {
 		return nil, err


### PR DESCRIPTION
@paultag 

## Issue
Attempting to compile with go version 1.15.3 results in:

```bash
$ brew install yubico-piv-tool
$ go get pault.ag/go/ykpiv
../../pault.ag/go/ykpiv/ykpiv.go:539:12: _Ctype_struct_ykpiv_state can't be allocated in Go; it is incomplete (or unallocatable)
../../pault.ag/go/ykpiv/ykpiv.go:569:11: _Ctype_struct_ykpiv_state can't be allocated in Go; it is incomplete (or unallocatable)
```
See release notes here: https://golang.org/doc/devel/release.html#go1.15

## Fix
Changing how `C.ykpiv_state` values are instantiated so compiler is happy.

## Reference(s)
See also: https://github.com/gotk3/gotk3/pull/669/commits/7fdd657f73fcadb76d77796589cfcd56c9ef6cbd

## Notes
Also ran `go mod tidy` and deps were updated, but happy to remove these changes if you wish.