### PR TITLE
cgo: use pkg-config

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -21,10 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/errors.go
+++ b/errors.go
@@ -21,10 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 */
 import "C"

--- a/generate.go
+++ b/generate.go
@@ -21,10 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/pivman.go
+++ b/pivman.go
@@ -21,10 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/sign.go
+++ b/sign.go
@@ -21,10 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/slot.go
+++ b/slot.go
@@ -21,10 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/ykpiv.go
+++ b/ykpiv.go
@@ -24,12 +24,7 @@ package ykpiv
 //      when I build it. For now this will keep it quiet :\
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
-#cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
-#cgo linux LDFLAGS: -lykpiv -Wl,--allow-multiple-definition
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
-#cgo windows CFLAGS: -I./win/include/ykpiv/
-#cgo windows LDFLAGS: ./win/lib/libykpiv.dll.a
+#cgo pkg-config: ykpiv
 #include <ykpiv.h>
 #include <stdlib.h>
 */


### PR DESCRIPTION
The code currently hardcodes per-platform include directories, which broke when
I made the Debian package install the headers in `/usr/include/$(DEB_HOST_ARCH)`